### PR TITLE
Use existing faster cryptoprimitives from golang.org/x/crypto

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -10,9 +10,9 @@ import (
 	"hash"
 	"io"
 
-	"github.com/devi/chap"
 	"github.com/minio/blake2b-simd"
 	"golang.org/x/crypto/blake2s"
+	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/curve25519"
 )
 
@@ -161,8 +161,12 @@ func cipherAESGCM(k [32]byte) Cipher {
 var CipherChaChaPoly CipherFunc = cipherFn{cipherChaChaPoly, "ChaChaPoly"}
 
 func cipherChaChaPoly(k [32]byte) Cipher {
+	c, err := chacha20poly1305.New(k[:])
+	if err != nil {
+		panic(err)
+	}
 	return aeadCipher{
-		chap.NewCipher(&k),
+		c,
 		func(n uint64) []byte {
 			var nonce [12]byte
 			binary.LittleEndian.PutUint64(nonce[4:], n)

--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -10,9 +10,9 @@ import (
 	"hash"
 	"io"
 
-	"github.com/devi/blake2/blake2s"
 	"github.com/devi/chap"
 	"github.com/minio/blake2b-simd"
+	"golang.org/x/crypto/blake2s"
 	"golang.org/x/crypto/curve25519"
 )
 
@@ -201,5 +201,13 @@ var HashSHA512 HashFunc = hashFn{sha512.New, "SHA512"}
 // HashBLAKE2b is the BLAKE2b hash function.
 var HashBLAKE2b HashFunc = hashFn{blake2b.New512, "BLAKE2b"}
 
+func blake2sNew() hash.Hash {
+	h, err := blake2s.New256(nil)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
 // HashBLAKE2s is the BLAKE2s hash function.
-var HashBLAKE2s HashFunc = hashFn{blake2s.New, "BLAKE2s"}
+var HashBLAKE2s HashFunc = hashFn{blake2sNew, "BLAKE2s"}


### PR DESCRIPTION
golang.org/x/crypto contains BLAKE2s and ChaCha20-Poly1305 implementations with assembler inclusions. Also it contains BLAKE2b, but have not checked is it either better or faster than existing dependent one.