### PR TITLE
Add CipherState Rekey

### DIFF
--- a/noise_test.go
+++ b/noise_test.go
@@ -2,7 +2,6 @@ package noise
 
 import (
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -516,25 +515,30 @@ func TestRekey(t *testing.T) {
 	oldK := csI0.k
 	csI0.Rekey()
 	assert.NotEqual(oldK, csI0.k, "should NOT be equal")
+	csR0.Rekey()
+
+	clientMessage = []byte("hello again")
+	msg = csI0.Encrypt(nil, nil, clientMessage)
+	res, err = csR0.Decrypt(nil, nil, msg)
+	assert.Equal(clientMessage, res, "server received unexpected message")
 
 	serverMessage := []byte("bye")
 	msg = csR1.Encrypt(nil, nil, serverMessage)
 	res, err = csI1.Decrypt(nil, nil, msg)
 	assert.Equal(serverMessage, res, "client received unexpected message")
 
+	csR1.Rekey()
+	csI1.Rekey()
+
 	serverMessage = []byte("bye bye")
 	msg = csR1.Encrypt(nil, nil, serverMessage)
 	res, err = csI1.Decrypt(nil, nil, msg)
 	assert.Equal(serverMessage, res, "client received unexpected message")
 
-	clientMessage = []byte("hello again")
-	msg = csI0.Encrypt(nil, nil, clientMessage)
-	res, err = csR0.Decrypt(nil, nil, msg)
-	fmt.Println("server decrypt message from client:", string(res))
-	assert.Equal(clientMessage, res, "server received unexpected message")
-
+	// only rekey one side, test for failure
+	csR1.Rekey()
 	serverMessage = []byte("bye again")
 	msg = csR1.Encrypt(nil, nil, serverMessage)
 	res, err = csI1.Decrypt(nil, nil, msg)
-	assert.Equal(serverMessage, res, "client received unexpected message")
+	assert.NotEqual(serverMessage, res, "client received unexpected message")
 }

--- a/noise_test.go
+++ b/noise_test.go
@@ -511,7 +511,7 @@ func (NoiseSuite) TestRekey(c *C) {
 
 	oldK := csI0.k
 	csI0.Rekey()
-	c.Assert(oldK == csI0.k, Equals, false)
+	c.Assert(oldK, Not(Equals), csI0.k)
 	csR0.Rekey()
 
 	clientMessage = []byte("hello again")
@@ -537,5 +537,5 @@ func (NoiseSuite) TestRekey(c *C) {
 	serverMessage = []byte("bye again")
 	msg = csR1.Encrypt(nil, nil, serverMessage)
 	res, err = csI1.Decrypt(nil, nil, msg)
-	c.Assert(string(serverMessage) == string(res), Equals, false)
+	c.Assert(string(serverMessage), Not(Equals), string(res))
 }

--- a/noise_test.go
+++ b/noise_test.go
@@ -2,8 +2,10 @@ package noise
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 )
 
@@ -463,4 +465,76 @@ func (NoiseSuite) TestHandshakeRollback(c *C) {
 
 	expected, _ := hex.DecodeString("07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7c5e4dc9545d41b3280f4586a5481829e1e24ec5a0")
 	c.Assert(msg, DeepEquals, expected)
+}
+
+func TestRekey(t *testing.T) {
+	assert := assert.New(t)
+
+	rng := new(RandomInc)
+
+	clientStaticKeypair := DH25519.GenerateKeypair(rng)
+	clientConfig := Config{}
+	clientConfig.CipherSuite = NewCipherSuite(DH25519, CipherChaChaPoly, HashBLAKE2b)
+	clientConfig.Random = rng
+	clientConfig.Pattern = HandshakeNN
+	clientConfig.Initiator = true
+	clientConfig.Prologue = []byte{0}
+	clientConfig.StaticKeypair = clientStaticKeypair
+	clientConfig.EphemeralKeypair = DH25519.GenerateKeypair(rng)
+	clientHs := NewHandshakeState(clientConfig)
+
+	serverStaticKeypair := DH25519.GenerateKeypair(rng)
+	serverConfig := Config{}
+	serverConfig.CipherSuite = NewCipherSuite(DH25519, CipherChaChaPoly, HashBLAKE2b)
+	serverConfig.Random = rng
+	serverConfig.Pattern = HandshakeNN
+	serverConfig.Initiator = false
+	serverConfig.Prologue = []byte{0}
+	serverConfig.StaticKeypair = serverStaticKeypair
+	serverConfig.EphemeralKeypair = DH25519.GenerateKeypair(rng)
+	serverHs := NewHandshakeState(serverConfig)
+
+	clientHsMsg, _, _ := clientHs.WriteMessage(nil, nil)
+	assert.Equal(32, len(clientHsMsg), "client handshake message is unexpected size")
+
+	serverHsResult, _, _, err := serverHs.ReadMessage(nil, clientHsMsg)
+	assert.NoError(err, "server failed to read client handshake message")
+	assert.Equal(0, len(serverHsResult), "server result message is unexpected size")
+
+	serverHsMsg, csR0, csR1 := serverHs.WriteMessage(nil, nil)
+	assert.Equal(48, len(serverHsMsg), "server handshake message is unexpected size")
+
+	clientHsResult, csI0, csI1, err := clientHs.ReadMessage(nil, serverHsMsg)
+	assert.NoError(err, "client failed to read server handshake message")
+	assert.Equal(0, len(clientHsResult), "client result message is unexpected size")
+
+	clientMessage := []byte("hello")
+	msg := csI0.Encrypt(nil, nil, clientMessage)
+	res, err := csR0.Decrypt(nil, nil, msg)
+	assert.Equal(clientMessage, res, "server received unexpected message")
+
+	oldK := csI0.k
+	csI0.Rekey()
+	assert.NotEqual(oldK, csI0.k, "should NOT be equal")
+
+	serverMessage := []byte("bye")
+	msg = csR1.Encrypt(nil, nil, serverMessage)
+	res, err = csI1.Decrypt(nil, nil, msg)
+	assert.Equal(serverMessage, res, "client received unexpected message")
+
+	serverMessage = []byte("bye bye")
+	msg = csR1.Encrypt(nil, nil, serverMessage)
+	res, err = csI1.Decrypt(nil, nil, msg)
+	assert.Equal(serverMessage, res, "client received unexpected message")
+
+	clientMessage = []byte("hello again")
+	msg = csI0.Encrypt(nil, nil, clientMessage)
+	res, err = csR0.Decrypt(nil, nil, msg)
+	fmt.Println("server decrypt message from client:", string(res))
+	assert.Equal(clientMessage, res, "server received unexpected message")
+
+	serverMessage = []byte("bye again")
+	msg = csR1.Encrypt(nil, nil, serverMessage)
+	res, err = csI1.Decrypt(nil, nil, msg)
+	assert.Equal(serverMessage, res, "client received unexpected message")
 }

--- a/state.go
+++ b/state.go
@@ -64,7 +64,9 @@ func (s *CipherState) Cipher() Cipher {
 
 func (s *CipherState) Rekey() {
 	var zeros [32]byte
-	s.c.Encrypt(s.k[:], math.MaxUint64, []byte{}, zeros[:])
+	var out []byte
+	out = s.c.Encrypt(out, math.MaxUint64, []byte{}, zeros[:])
+	copy(s.k[:], out[:32])
 }
 
 type symmetricState struct {

--- a/state.go
+++ b/state.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 )
 
 // A CipherState provides symmetric encryption and decryption after a successful
@@ -59,6 +60,11 @@ func (s *CipherState) Decrypt(out, ad, ciphertext []byte) ([]byte, error) {
 func (s *CipherState) Cipher() Cipher {
 	s.invalid = true
 	return s.c
+}
+
+func (s *CipherState) Rekey() {
+	var zeros [32]byte
+	s.k = s.c.Encrypt(s.k, math.MaxUint64, []byte{}, zeros[:])
 }
 
 type symmetricState struct {

--- a/state.go
+++ b/state.go
@@ -63,9 +63,9 @@ func (s *CipherState) Cipher() Cipher {
 
 type symmetricState struct {
 	CipherState
-	hasK   bool
-	ck     []byte
-	h      []byte
+	hasK bool
+	ck   []byte
+	h    []byte
 
 	prevCK []byte
 	prevH  []byte
@@ -199,7 +199,7 @@ type HandshakeState struct {
 	e               DHKey  // local ephemeral keypair
 	rs              []byte // remote party's static public key
 	re              []byte // remote party's ephemeral public key
-	psk		[]byte // preshared key, maybe zero length
+	psk             []byte // preshared key, maybe zero length
 	messagePatterns [][]MessagePattern
 	shouldWrite     bool
 	msgIdx          int
@@ -277,10 +277,10 @@ func NewHandshakeState(c Config) *HandshakeState {
 		}
 		pskModifier = fmt.Sprintf("psk%d", c.PresharedKeyPlacement)
 		hs.messagePatterns = append([][]MessagePattern(nil), hs.messagePatterns...)
-		if (c.PresharedKeyPlacement == 0) {
+		if c.PresharedKeyPlacement == 0 {
 			hs.messagePatterns[0] = append([]MessagePattern{MessagePatternPSK}, hs.messagePatterns[0]...)
 		} else {
-			hs.messagePatterns[c.PresharedKeyPlacement - 1] = append(hs.messagePatterns[c.PresharedKeyPlacement - 1], MessagePatternPSK)
+			hs.messagePatterns[c.PresharedKeyPlacement-1] = append(hs.messagePatterns[c.PresharedKeyPlacement-1], MessagePatternPSK)
 		}
 	}
 	hs.ss.InitializeSymmetric([]byte("Noise_" + c.Pattern.Name + pskModifier + "_" + string(hs.ss.cs.Name())))

--- a/state.go
+++ b/state.go
@@ -67,6 +67,7 @@ func (s *CipherState) Rekey() {
 	var out []byte
 	out = s.c.Encrypt(out, math.MaxUint64, []byte{}, zeros[:])
 	copy(s.k[:], out[:32])
+	s.c = s.cs.Cipher(s.k)
 }
 
 type symmetricState struct {

--- a/state.go
+++ b/state.go
@@ -64,7 +64,7 @@ func (s *CipherState) Cipher() Cipher {
 
 func (s *CipherState) Rekey() {
 	var zeros [32]byte
-	s.k = s.c.Encrypt(s.k, math.MaxUint64, []byte{}, zeros[:])
+	s.c.Encrypt(s.k[:], math.MaxUint64, []byte{}, zeros[:])
 }
 
 type symmetricState struct {


### PR DESCRIPTION

as per issue https://github.com/flynn/noise/issues/13 i've implemented Rekey as specified in section 4.2 of http://noiseprotocol.org/noise.html however we could certainly rewrite this to use chacha20 instead of CipherState's CipherSuite's Encrypt.