### PR TITLE
added GetNonce and SetNonce following Noise revision 33 (aimed at UDP-based protocols)

### DIFF
--- a/noise_test.go
+++ b/noise_test.go
@@ -539,3 +539,79 @@ func (NoiseSuite) TestRekey(c *C) {
 	res, err = csI1.Decrypt(nil, nil, msg)
 	c.Assert(string(serverMessage), Not(Equals), string(res))
 }
+
+func (NoiseSuite) TestSetNonce(c *C) {
+	rng := new(RandomInc)
+
+	clientStaticKeypair, _ := DH25519.GenerateKeypair(rng)
+	clientConfig := Config{}
+	clientConfig.CipherSuite = NewCipherSuite(DH25519, CipherChaChaPoly, HashBLAKE2b)
+	clientConfig.Random = rng
+	clientConfig.Pattern = HandshakeNN
+	clientConfig.Initiator = true
+	clientConfig.Prologue = []byte{0}
+	clientConfig.StaticKeypair = clientStaticKeypair
+	clientConfig.EphemeralKeypair, _ = DH25519.GenerateKeypair(rng)
+	clientHs, _ := NewHandshakeState(clientConfig)
+
+	serverStaticKeypair, _ := DH25519.GenerateKeypair(rng)
+	serverConfig := Config{}
+	serverConfig.CipherSuite = NewCipherSuite(DH25519, CipherChaChaPoly, HashBLAKE2b)
+	serverConfig.Random = rng
+	serverConfig.Pattern = HandshakeNN
+	serverConfig.Initiator = false
+	serverConfig.Prologue = []byte{0}
+	serverConfig.StaticKeypair = serverStaticKeypair
+	serverConfig.EphemeralKeypair, _ = DH25519.GenerateKeypair(rng)
+	serverHs, _ := NewHandshakeState(serverConfig)
+
+	clientHsMsg, _, _, _ := clientHs.WriteMessage(nil, nil)
+	c.Assert(32, Equals, len(clientHsMsg))
+
+	serverHsResult, _, _, err := serverHs.ReadMessage(nil, clientHsMsg)
+	c.Assert(err, IsNil)
+	c.Assert(0, Equals, len(serverHsResult))
+
+	serverHsMsg, csR0, csR1, _ := serverHs.WriteMessage(nil, nil)
+	c.Assert(48, Equals, len(serverHsMsg))
+
+	clientHsResult, csI0, csI1, err := clientHs.ReadMessage(nil, serverHsMsg)
+	c.Assert(err, IsNil)
+	c.Assert(0, Equals, len(clientHsResult))
+
+	clientMessage := []byte("hello")
+	msg := csI0.Encrypt(nil, nil, clientMessage)
+	res, err := csR0.Decrypt(nil, nil, msg)
+	c.Assert(string(clientMessage), Equals, string(res))
+
+	// dropped messages
+	csI0.Encrypt(nil, nil, clientMessage)
+	csI0.Encrypt(nil, nil, clientMessage)
+	csI0.Encrypt(nil, nil, clientMessage)
+	csI0.Encrypt(nil, nil, clientMessage)
+	// GetNonce/SetNonce
+	nonce := csI0.GetNonce()
+	csR0.SetNonce(nonce)
+
+	clientMessage = []byte("hello again")
+	msg = csI0.Encrypt(nil, nil, clientMessage)
+	res, err = csR0.Decrypt(nil, nil, msg)
+	c.Assert(string(clientMessage), Equals, string(res))
+
+	serverMessage := []byte("bye")
+	msg = csR1.Encrypt(nil, nil, serverMessage)
+	res, err = csI1.Decrypt(nil, nil, msg)
+	c.Assert(string(serverMessage), Equals, string(res))
+
+	// dropped messages
+	csR1.Encrypt(nil, nil, clientMessage)
+	csR1.Encrypt(nil, nil, clientMessage)
+	// GetNonce/SetNonce
+	nonce = csR1.GetNonce()
+	csI1.SetNonce(nonce)
+
+	serverMessage = []byte("bye bye")
+	msg = csR1.Encrypt(nil, nil, serverMessage)
+	res, err = csI1.Decrypt(nil, nil, msg)
+	c.Assert(string(serverMessage), Equals, string(res))
+}

--- a/state.go
+++ b/state.go
@@ -25,6 +25,23 @@ type CipherState struct {
 	invalid bool
 }
 
+// GetNonce is a nonce getter useful for out-of-order protocols where
+// the nonce must be explicitly sent in addition to encrypted application data.
+// It is to be used in conjunction with SetNonce(). More information is available
+// in Section 11.4 (Out-of-order transport messages) of the Noise framework protocol.
+func (s CipherState) GetNonce() uint64 {
+	return s.n
+}
+
+// SetNonce is a helper for handling of out-of-order transport messages.
+// When receiving an explicit nonce from an encrypted message, SetNonce
+// can be used to set the decryption nonce to the received one. More information
+// is available in Section 11.4 (Out-of-order transport messages) of the
+// Noise framework protocol.
+func (s *CipherState) SetNonce(nonce uint64) {
+	s.n = nonce
+}
+
 // Encrypt encrypts the plaintext and then appends the ciphertext and an
 // authentication tag across the ciphertext and optional authenticated data to
 // out. This method automatically increments the nonce after every call, so


### PR DESCRIPTION
Hello hello,

Following Noise revision 33, a `SetNonce()` function was added. Its behavior is pretty straight forward, still added a test that passes.