### PR TITLE
Add a getter for handshake msgIdx

### DIFF
--- a/state.go
+++ b/state.go
@@ -490,3 +490,8 @@ func (s *HandshakeState) ChannelBinding() []byte {
 func (s *HandshakeState) PeerStatic() []byte {
 	return s.rs
 }
+
+// MessageIndex returns the current handshake message id
+func (s *HandshakeState) MessageIndex() int {
+	return s.msgIdx
+}


### PR DESCRIPTION
Adds a getter for `msgIdx` in the handshake state. Having this would make it so we could understand the the current state of the handshake and avoid tracking it independently.