### PR TITLE
Use X25519 instead of ScalarMult for safety

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -30,7 +30,7 @@ type DHFunc interface {
 
 	// DH performs a Diffie-Hellman calculation between the provided private and
 	// public keys and returns the result.
-	DH(privkey, pubkey []byte) []byte
+	DH(privkey, pubkey []byte) ([]byte, error)
 
 	// DHLen is the number of bytes returned by DH.
 	DHLen() int
@@ -116,12 +116,8 @@ func (dh25519) GenerateKeypair(rng io.Reader) (DHKey, error) {
 	return DHKey{Private: privkey[:], Public: pubkey[:]}, nil
 }
 
-func (dh25519) DH(privkey, pubkey []byte) []byte {
-	var dst, in, base [32]byte
-	copy(in[:], privkey)
-	copy(base[:], pubkey)
-	curve25519.ScalarMult(&dst, &in, &base)
-	return dst[:]
+func (dh25519) DH(privkey, pubkey []byte) ([]byte, error) {
+	return curve25519.X25519(privkey, pubkey)
 }
 
 func (dh25519) DHLen() int     { return 32 }

--- a/state.go
+++ b/state.go
@@ -359,21 +359,45 @@ func (s *HandshakeState) WriteMessage(out, payload []byte) ([]byte, *CipherState
 			}
 			out = s.ss.EncryptAndHash(out, s.s.Public)
 		case MessagePatternDHEE:
-			s.ss.MixKey(s.ss.cs.DH(s.e.Private, s.re))
+			dh, err := s.ss.cs.DH(s.e.Private, s.re)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			s.ss.MixKey(dh)
 		case MessagePatternDHES:
 			if s.initiator {
-				s.ss.MixKey(s.ss.cs.DH(s.e.Private, s.rs))
+				dh, err := s.ss.cs.DH(s.e.Private, s.rs)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			} else {
-				s.ss.MixKey(s.ss.cs.DH(s.s.Private, s.re))
+				dh, err := s.ss.cs.DH(s.s.Private, s.re)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			}
 		case MessagePatternDHSE:
 			if s.initiator {
-				s.ss.MixKey(s.ss.cs.DH(s.s.Private, s.re))
+				dh, err := s.ss.cs.DH(s.s.Private, s.re)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			} else {
-				s.ss.MixKey(s.ss.cs.DH(s.e.Private, s.rs))
+				dh, err := s.ss.cs.DH(s.e.Private, s.rs)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			}
 		case MessagePatternDHSS:
-			s.ss.MixKey(s.ss.cs.DH(s.s.Private, s.rs))
+			dh, err := s.ss.cs.DH(s.s.Private, s.rs)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			s.ss.MixKey(dh)
 		case MessagePatternPSK:
 			s.ss.MixKeyAndHash(s.psk)
 		}
@@ -447,21 +471,45 @@ func (s *HandshakeState) ReadMessage(out, message []byte) ([]byte, *CipherState,
 			}
 			message = message[expected:]
 		case MessagePatternDHEE:
-			s.ss.MixKey(s.ss.cs.DH(s.e.Private, s.re))
+			dh, err := s.ss.cs.DH(s.e.Private, s.re)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			s.ss.MixKey(dh)
 		case MessagePatternDHES:
 			if s.initiator {
-				s.ss.MixKey(s.ss.cs.DH(s.e.Private, s.rs))
+				dh, err := s.ss.cs.DH(s.e.Private, s.rs)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			} else {
-				s.ss.MixKey(s.ss.cs.DH(s.s.Private, s.re))
+				dh, err := s.ss.cs.DH(s.s.Private, s.re)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			}
 		case MessagePatternDHSE:
 			if s.initiator {
-				s.ss.MixKey(s.ss.cs.DH(s.s.Private, s.re))
+				dh, err := s.ss.cs.DH(s.s.Private, s.re)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			} else {
-				s.ss.MixKey(s.ss.cs.DH(s.e.Private, s.rs))
+				dh, err := s.ss.cs.DH(s.e.Private, s.rs)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				s.ss.MixKey(dh)
 			}
 		case MessagePatternDHSS:
-			s.ss.MixKey(s.ss.cs.DH(s.s.Private, s.rs))
+			dh, err := s.ss.cs.DH(s.s.Private, s.rs)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			s.ss.MixKey(dh)
 		case MessagePatternPSK:
 			s.ss.MixKeyAndHash(s.psk)
 		}


### PR DESCRIPTION
In practice we should never encounter errors, and this does not appear to be a security issue, but the ScalarMult function is deprecated (see https://github.com/golang/go/issues/32670).

@AxbB36 @nbrownus @rawdigits 