### PR TITLE
Add SetNonce to CipherState

### DIFF
--- a/state.go
+++ b/state.go
@@ -86,6 +86,11 @@ func (s *CipherState) Nonce() uint64 {
 	return s.n
 }
 
+// SetNonce sets the current value of n.
+func (s *CipherState) SetNonce(n uint64) {
+	s.n = n
+}
+
 func (s *CipherState) Rekey() {
 	var zeros [32]byte
 	var out []byte


### PR DESCRIPTION
The `SetNonce` function of `CipherState` is specified at https://noiseprotocol.org/noise.html#the-cipherstate-object.

I found this function necessary in implementing a protocol with [out-of-order transport messages](https://noiseprotocol.org/noise.html#out-of-order-transport-messages).